### PR TITLE
Revert to original query

### DIFF
--- a/sql_search/sql_search_cohere_langchain.ipynb
+++ b/sql_search/sql_search_cohere_langchain.ipynb
@@ -417,7 +417,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query = \"What is the average balance of all management jobs who applied for banking deposits?\""
+    "query = \"How many people with management jobs applied for a banking deposit in May?\""
    ]
   },
   {


### PR DESCRIPTION
The query doesn't match the question immediately above it. I recall Mark changing the question during the demo, so perhaps this got saved. If this was the intended query then you can ignore my code change but perhaps change the question in the markdown cell immediately above so they match.